### PR TITLE
Fixed ETag typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also gzip the files before sending them, just add `--gzip` parameter.
 
 You can also specify the `Cache-Control: max-age=X` header, where X is the number of seconds given item will be kept in the cache for. Just add `--cache X` parameter. By default this value is undefined.
 
-You can also specify the `ETag: X` header, where X is either user-defined value for this header, or MD5 of the content. To provide a custom value use `--etag X` parameter. To automatically fill this header with MD5 hash of the file, just use `--tag` parameter without any value. Internally the tool will generate MD5 hash of the content and will set it as the ETag header value. By default this parameter is undefined.
+You can also specify the `ETag: X` header, where X is either user-defined value for this header, or MD5 of the content. To provide a custom value use `--etag X` parameter. To automatically fill this header with MD5 hash of the file, just use `--etag` parameter without any value. Internally the tool will generate MD5 hash of the content and will set it as the ETag header value. By default this parameter is undefined.
 
 ## Commands
 


### PR DESCRIPTION
There was a small typo in the README.md ('--tag' instead of '--etag') that caused a little confusion.
